### PR TITLE
Update collection-type to series

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -42,7 +42,7 @@
 		<meta property="se:subject">Children’s</meta>
 		<meta property="se:subject">Fiction</meta>
 		<meta id="collection-1" property="belongs-to-collection">Newbery Medal Winners</meta>
-		<meta property="collection-type" refines="#collection-1">set</meta>
+		<meta property="collection-type" refines="#collection-1">series</meta>
 		<meta property="group-position" refines="#collection-1">6</meta>
 		<dc:description id="description">Smoky, a gray-colored horse, grows into adulthood on the ranges of the American West.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">


### PR DESCRIPTION
Changing it to match _The Voyages of Doctor Dolittle_:

https://github.com/standardebooks/hugh-lofting_the-voyages-of-doctor-dolittle/blob/653e196f1537671e793960f1e1b7347ce68dca00/src/epub/content.opf#L50

This was the only `set`/`series` inconsistency I found.

The way it's looking like the DB is going, the first book in a collection will write the collection type, and the type will be ignored for the rest. We don't currently have a way to check for this in a `Validate()` method, but maybe in the future. 